### PR TITLE
Added missing string types

### DIFF
--- a/Simple.Data.Oracle/DbTypeConverter.cs
+++ b/Simple.Data.Oracle/DbTypeConverter.cs
@@ -14,23 +14,31 @@ namespace Simple.Data.Oracle
         private static readonly Dictionary<string, DbType> _types =
             new Dictionary<string, DbType>(StringComparer.InvariantCultureIgnoreCase)
                 {
-                    {"VARCHAR2", DbType.String},
-                    {"NUMBER", DbType.Decimal},
                     {"CHAR", DbType.StringFixedLength},
+                    {"NCHAR", DbType.StringFixedLength},
+                    {"VARCHAR2", DbType.String},
+                    {"NVARCHAR2", DbType.String},
+                    {"NUMBER", DbType.Decimal},
                     {"DATE", DbType.Date},
                     {"TIMESTAMP(6)", DbType.Date},
                     {"RAW", DbType.Binary},
+                    {"RAW(16)", DbType.Guid},
                 };
 
         private static readonly Dictionary<string, Type> _dbToClr =
             new Dictionary<string, Type>
                 {
+                    {"CHAR", typeof (string)},
+                    {"NCHAR", typeof (string)},
                     {"VARCHAR2", typeof (string)},
+                    {"NVARCHAR2", typeof (string)},
                     {"NUMBER", typeof (decimal)},
                     {"DATE", typeof (DateTime)},
                     {"TIMESTAMP", typeof (DateTime)},
                     {"RAW", typeof (Guid)},
-                    {"BLOB", typeof (byte[])}
+                    {"BLOB", typeof (byte[])},
+                    {"REF CURSOR", typeof (object)},
+                    {"PL/SQL BOOLEAN", typeof (object)},
                 };
 
         public static DbType FromDataType(string dataType)


### PR DESCRIPTION
I ran some tests against my Oracle database, and it failed due to a few types that I've added. Some of them were common, like NVARCHAR2, a couple of others were more exotic, like REF CURSOR that was used in a stored procedure.

A comment about type mapping. I see that all numeric types are mapped to decimal. Shouldn't the provider do a more precise mapping? For example, NUMBER(1) should be mapped to bool, NUMBER(2) to NUMBER(9) correspond to int etc. If you want this more specific mapping, I can implement it, but then current approach based on data type name lookup must be changed: it's a pair of (datatype, datalength) that should give a matching type.
