### PR TITLE
Fix when using a shared connection without a transaction

### DIFF
--- a/Simple.Data.Oracle/OracleInserter.cs
+++ b/Simple.Data.Oracle/OracleInserter.cs
@@ -27,7 +27,7 @@ namespace Simple.Data.Oracle
                     {
                         var c = transaction != null
                                     ? transaction.Connection.CreateCommand()
-                                    : adapter.ConnectionProvider.CreateConnection().CreateCommand();
+                                    : adapter.CreateConnection().CreateCommand();
                         return c;
                     };
 


### PR DESCRIPTION
Hi Frank,

I've made another small change to the Oracle inserter and a unit test to cover the change. In our appllication we use a shared connection in the adoadapter and an outer TransactionScope object to manage the overall transaction in this case the sequence currval was not working because the inserter created a new connection each time. The inserter now calls the Adapter.CreateConnection() function, which honours the shared connection.

Thanks,

Simon
