### PR TITLE
Ensures that the connection is closed.

### DIFF
--- a/Simple.Data.Oracle/OracleInserter.cs
+++ b/Simple.Data.Oracle/OracleInserter.cs
@@ -31,8 +31,7 @@ namespace Simple.Data.Oracle
                         return c;
                     };
 
-            IDbCommand cmd;
-            using (cmd = ConstructCommand(tuples, table.QualifiedName, command))
+            using (var cmd = ConstructCommand(tuples, table.QualifiedName, command))
             {
                 cmd.WriteTrace();
                 cmd.Connection.TryOpen();
@@ -41,6 +40,9 @@ namespace Simple.Data.Oracle
                 foreach (var it in tuples.Values)
                     returnData.Add(it.SimpleDataColumn, NormalizeReturningValue((IDbDataParameter)cmd.Parameters[it.ReturningParameterName]));
                 data = returnData;
+
+                if (cmd.Connection.State == ConnectionState.Open)
+                    cmd.Connection.Close();
             }
 
             return data;


### PR DESCRIPTION
This ensures that the insert connection is closed because after a insert action to the Oracle Database is done, the current Connection is open in "Innactive" mode and when the pull reach the maximum the aplication throws the follow error:

``` javascript
Error : Timeout expired. The timeout period elapsed prior to obtaining a connection from the pool. This may have occurred because all pooled connections were in use and max pool size was reached.
```
